### PR TITLE
feat(projects): add create project action with validation and logic

### DIFF
--- a/src/lib/actions/projects/createProject/action.ts
+++ b/src/lib/actions/projects/createProject/action.ts
@@ -1,0 +1,15 @@
+"use server";
+
+import { authActionClient } from "@/lib/createSafeAction";
+import { createProject } from "./logic";
+import { createProjectSchema } from "./schema";
+
+export const createProjectAction = authActionClient
+  .inputSchema(createProjectSchema)
+  .action(async ({ parsedInput, ctx }) => {
+    try {
+      return await createProject(parsedInput, ctx.user.userId);
+    } catch (error) {
+      throw new Error("Something went wrong", { cause: error });
+    }
+  });

--- a/src/lib/actions/projects/createProject/logic.ts
+++ b/src/lib/actions/projects/createProject/logic.ts
@@ -1,0 +1,26 @@
+"use server";
+
+import { prisma } from "@/lib/prisma";
+import { error, Result, success } from "@/lib/result";
+import { Project } from "@/generated/prisma";
+import { CreateProjectInput } from "./schema";
+
+export async function createProject(input: CreateProjectInput, userId: string): Promise<Result<Project>> {
+  try {
+    const { title, type } = input;
+
+    // Create the project
+    const newProject = await prisma.project.create({
+      data: {
+        title,
+        type,
+        userId
+      }
+    });
+
+    return success(newProject);
+  } catch (err) {
+    console.error("Project creation error:", err);
+    return error("Internal server error");
+  }
+}

--- a/src/lib/actions/projects/createProject/schema.ts
+++ b/src/lib/actions/projects/createProject/schema.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const createProjectSchema = z.object({
+  title: z.string().min(1, "Title is required"),
+  type: z.enum(["post", "article", "ebook", "script"], {
+    message: "Invalid project type"
+  })
+});
+
+export type CreateProjectInput = z.infer<typeof createProjectSchema>;


### PR DESCRIPTION
Implement server action for creating projects including schema validation and database interaction. The action handles input validation using Zod and persists projects to the database via Prisma.