### PR TITLE
feat: Update ProjectType enum in Prisma schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,10 +34,9 @@ enum Role {
 }
 
 enum ProjectType {
-  post
   article
   ebook
-  script
+  newsletter
 }
 
 model Project {

--- a/src/components/models/projects/CreateProjectForm.tsx
+++ b/src/components/models/projects/CreateProjectForm.tsx
@@ -50,10 +50,6 @@ export function CreateProjectForm() {
           control={form.control}
           items={[
             {
-              label: 'Post',
-              value: 'post'
-            },
-            {
               label: 'Article',
               value: 'article'
             },
@@ -62,8 +58,8 @@ export function CreateProjectForm() {
               value: 'ebook'
             },
             {
-              label: 'Script',
-              value: 'script'
+              label: 'Newsletter',
+              value: 'newsletter'
             }
           ]}
           name='type'


### PR DESCRIPTION
This PR updates the `ProjectType` enum in `prisma/schema.prisma`.

**Motivation:**
- Remove 'post' and 'script' types as they are no longer needed.
- Add 'newsletter' type to support new project requirements.

**Changes Made:**
- Modified `prisma/schema.prisma` to reflect the updated `ProjectType` enum.
- A new migration file will be generated to apply these schema changes to the database.
- All occurrences of 'post' and 'script' in the codebase related to `ProjectType` will need to be updated to 'newsletter' or other valid types.

**Review Notes:**
- Please review the schema changes in `prisma/schema.prisma`.
- Verify that the generated migration correctly reflects the enum changes.
- Ensure all code references to `ProjectType` are updated to handle the new enum values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Newsletter” as a selectable project type when creating a project.

* **Chores**
  * Removed “Post” and “Script” project type options from the creation form and underlying allowed values.
  * Existing project types “Article” and “eBook” remain available.
  * Default project type remains “Article.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->